### PR TITLE
build-fix

### DIFF
--- a/Assets/Scripts/OrchestraArmy/Entity/Entities/Player/Controllers/PlayerDirectionController.cs
+++ b/Assets/Scripts/OrchestraArmy/Entity/Entities/Player/Controllers/PlayerDirectionController.cs
@@ -16,6 +16,7 @@ namespace OrchestraArmy.Entity.Entities.Player.Controllers
             var entityPosition = Entity.transform.position;
             var entityScreenPosition = Camera.WorldToScreenPoint(entityPosition);
             var mousePosition = Input.mousePosition;
+            var cameraRotation = Camera.transform.rotation.eulerAngles;
 
             if (Mathf.Abs(Vector3.Distance(mousePosition, entityScreenPosition)) < 40)
             {
@@ -24,17 +25,19 @@ namespace OrchestraArmy.Entity.Entities.Player.Controllers
             
             var angleRadians = Mathf.Atan2(entityScreenPosition.y - mousePosition.y, entityScreenPosition.x - mousePosition.x);
             var angle = angleRadians * (180 / Mathf.PI);
+            var compensatedAngle = angle - cameraRotation.y;
+            var compensatedRadians = compensatedAngle * (Mathf.PI / 180);
 
-            if (angle < -45 && angle > -135)
+            if (angle <= -45 && angle >= -135)
                 CurrentDirection = EntityDirection.Top;
-            else if (angle < -135 || angle > 135)
+            else if (angle <= -135 || angle >= 135)
                 CurrentDirection = EntityDirection.Right;
-            else if (angle > 45 && angle < 135)
+            else if (angle >= 45 && angle <= 135)
                 CurrentDirection = EntityDirection.Down;
-            else if (angle > -45 && angle < 135)
+            else if (angle >= -45 && angle <= 135)
                 CurrentDirection = EntityDirection.Left;
 
-            var directionVector = new Vector3(-Mathf.Cos(angleRadians), 0, -Mathf.Sin(angleRadians));
+            var directionVector = new Vector3(-Mathf.Cos(compensatedRadians), 0, -Mathf.Sin(compensatedRadians));
             
             Entity.transform.forward = directionVector;
 

--- a/Assets/Scripts/OrchestraArmy/Entity/Entities/Sprites/SpriteManager.cs
+++ b/Assets/Scripts/OrchestraArmy/Entity/Entities/Sprites/SpriteManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
@@ -56,18 +57,6 @@ namespace OrchestraArmy.Entity.Entities.Sprites
         public void UpdateSprite()
         {
             var direction = Entity.DirectionController.CurrentDirection;
-            var cameraRotation = Camera.transform.rotation.eulerAngles;
-
-            if ((direction == EntityDirection.Top || direction == EntityDirection.Down) && (cameraRotation.y > 90 && cameraRotation.y < 270))
-            {
-                var newDirection = (int) direction - 2;
-
-                if (newDirection < 0)
-                    newDirection += 4;
-
-                direction = (EntityDirection) newDirection;
-            }
-            
             var newSprite = Entity.Sprites.FirstOrDefault(s => s.Direction == direction);
 
             if (newSprite.Sprites == null || newSprite.Sprites.Length == 0)


### PR DESCRIPTION
Make the player rotate with the camera, turning around the player caused some conflicts with the consistency of the direction and position of the mouse